### PR TITLE
[ENH] results dict now returns permuted singular values

### DIFF
--- a/pyls/base.py
+++ b/pyls/base.py
@@ -368,6 +368,7 @@ class BasePLS():
             d_perm, ucorrs, vcorrs = self.permutation(X, Y, seed=self.rs)
             res['permres']['pvals'] = compute.perm_sig(res['singvals'], d_perm)
             res['permres']['permsamples'] = self.permsamp
+            res['permres']['perm_singval'] = d_perm
 
             if self.inputs.n_split is not None:
                 # get ucorr / vcorr (via split half resampling) for original,

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -292,7 +292,7 @@ class PLSPermResults(ResDict):
         Resampling array used to permute `S` samples over `P` permutations
     """
     allowed = [
-        'pvals', 'permsamples'
+        'pvals', 'permsamples', 'perm_singval'
     ]
 
 


### PR DESCRIPTION
Minor changes to output structure to allow permuted singular values to be returned. This allows us to compute non-parametric p-values with them.